### PR TITLE
VSCodeの設定からBiomeのものを削除

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,7 @@
 {
-	"recommendations": ["astro-build.astro-vscode", "biomejs.biome"],
+	"recommendations": [
+		"astro-build.astro-vscode",
+		"esbenp.prettier-vscode"
+	],
 	"unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-	"editor.defaultFormatter": "biomejs.biome",
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
-		"source.organizeImports.biome": "explicit"
+		"source.organizeImports": "explicit"
 	}
 }


### PR DESCRIPTION
7530802f15 でBiomeが削除されたがVSCodeの設定には反映されていなかった。
Biome関連の設定を削除し、フォーマッターの設定はPrettierに入れ替える。